### PR TITLE
Replace TipView with CustomFeaturedContentView

### DIFF
--- a/OCKSample.xcodeproj/project.pbxproj
+++ b/OCKSample.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		E72B2C0A226939E3009A9438 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72B2C09226939E3009A9438 /* AppDelegate.swift */; };
 		E72B2C14226939E4009A9438 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E72B2C12226939E4009A9438 /* LaunchScreen.storyboard */; };
 		E7C37849228F887800E982D8 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C37848228F887800E982D8 /* TipView.swift */; };
+		EEB9E5502FA25A0100658286 /* CustomFeaturedContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB9E54F2FA25A0100658286 /* CustomFeaturedContentView.swift */; };
 		E7C4CA0B22809AD500ECC3D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E7C4CA0A22809AD500ECC3D7 /* Assets.xcassets */; };
 		EEB9E53C2F94C90200658286 /* AnswerSummarySurveyCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB9E5342F94C8FF00658286 /* AnswerSummarySurveyCardView.swift */; };
 		EEB9E53E2F94D19F00658286 /* TappingSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB9E53D2F94D19D00658286 /* TappingSpeed.swift */; };
@@ -437,6 +438,7 @@
 		E72B2C13226939E4009A9438 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E72B2C15226939E4009A9438 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E7C37848228F887800E982D8 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
+		EEB9E54F2FA25A0100658286 /* CustomFeaturedContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFeaturedContentView.swift; sourceTree = "<group>"; };
 		E7C4CA0A22809AD500ECC3D7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		EEB9E5342F94C8FF00658286 /* AnswerSummarySurveyCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerSummarySurveyCardView.swift; sourceTree = "<group>"; };
 		EEB9E53D2F94D19D00658286 /* TappingSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TappingSpeed.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 			isa = PBXGroup;
 			children = (
 				EEB9E5342F94C8FF00658286 /* AnswerSummarySurveyCardView.swift */,
+				EEB9E54F2FA25A0100658286 /* CustomFeaturedContentView.swift */,
 				E7C37848228F887800E982D8 /* TipView.swift */,
 				3F73F9612F7CE1D4007D4222 /* SurveyViewSynchronizer.swift */,
 			);
@@ -1408,6 +1411,7 @@
 				FE38C3402F560F45000864F1 /* OCKDimensionStyle.swift in Sources */,
 				707CC718254DA91900116728 /* OCKLocalization.swift in Sources */,
 				E7C37849228F887800E982D8 /* TipView.swift in Sources */,
+				EEB9E5502FA25A0100658286 /* CustomFeaturedContentView.swift in Sources */,
 				3F3C42432F712B9E00A0FEAB /* CareKitCard.swift in Sources */,
 				3F4A12192F54F70800068C65 /* OCKAnimationStyle.swift in Sources */,
 				3F4A121A2F54F70800068C65 /* OCKAppearanceStyle.swift in Sources */,

--- a/OCKSample/Main/Cards/UIKit/CustomFeaturedContentView.swift
+++ b/OCKSample/Main/Cards/UIKit/CustomFeaturedContentView.swift
@@ -1,0 +1,66 @@
+/*
+ Copyright (c) 2019, Apple Inc. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1.  Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2.  Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation and/or
+ other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder(s) nor the names of any contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission. No license is granted to the trademarks of
+ the copyright holders even if such marks are included in this software.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if os(iOS)
+import CareKitUI
+import os.log
+import UIKit
+
+class CustomFeaturedContentView: OCKFeaturedContentView {
+
+    var url: URL?
+
+    override init(imageOverlayStyle: UIUserInterfaceStyle = .unspecified) {
+        super.init(imageOverlayStyle: imageOverlayStyle)
+        delegate = self
+    }
+
+    convenience init(
+        url: String,
+        imageOverlayStyle: UIUserInterfaceStyle = .unspecified
+    ) {
+        self.init(imageOverlayStyle: imageOverlayStyle)
+        self.url = URL(string: url)
+    }
+}
+
+extension CustomFeaturedContentView: OCKFeaturedContentViewDelegate {
+    nonisolated func didTapView(_ view: OCKFeaturedContentView) {
+        Task { @MainActor in
+            guard let url = self.url else {
+                Logger.feed.warning("CustomFeaturedContentView tapped but no URL configured")
+                return
+            }
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+#endif

--- a/OCKSample/Main/Care/CareViewController.swift
+++ b/OCKSample/Main/Care/CareViewController.swift
@@ -192,14 +192,14 @@ final class CareViewController: OCKDailyPageViewController, @unchecked Sendable 
             let isCurrentDay = isSameDay(as: date)
             if isCurrentDay {
                 if Calendar.current.isDate(date, inSameDayAs: Date()) {
-                    let tipTitle = "Caffeine & Your Health"
-                    let tipText = "High caffeine intake (>400 mg/day) is linked to increased anxiety"
-                    let tipView = TipView()
-                    tipView.headerView.titleLabel.text = tipTitle
-                    tipView.headerView.detailLabel.text = tipText
-                    tipView.imageView.image = UIImage(named: "exercise.jpg")
-                    tipView.customStyle = CustomStylerKey.defaultValue
-                    listViewController.appendView(tipView, animated: false)
+                    let featuredView = CustomFeaturedContentView(
+                        url: "https://www.cdc.gov/sleep/"
+                    )
+                    featuredView.label.text = "Caffeine & Your Health"
+                    featuredView.label.textColor = .white
+                    featuredView.imageView.image = UIImage(named: "exercise.jpg")
+                    featuredView.customStyle = CustomStylerKey.defaultValue
+                    listViewController.appendView(featuredView, animated: false)
                 }
             }
             #endif


### PR DESCRIPTION
## Summary
  - Added `CustomFeaturedContentView` subclassing `OCKFeaturedContentView` 
  - Completed all TODOs: delegate wiring, convenience initializer with URL, tap-to-open behavior 
  - Replaced `TipView` usage in `CareViewController` with the new featured content view                                 
  - Featured card opens CDC Sleep page when tapped                                                                      